### PR TITLE
Update Singleton.pm

### DIFF
--- a/lib/Script/Singleton.pm
+++ b/lib/Script/Singleton.pm
@@ -13,7 +13,9 @@ sub import {
 
     $params{glue} = abs_path((caller())[1]) if ! exists $params{glue};
 
-    IPC::Shareable->singleton($params{glue}, $params{warn});
+    IPC::Shareable->singleton($params{glue}, $params{warn}) if (!$^C);
+    
+    $SIG{INT} = $SIG{TERM} = sub {IPC::Shareable->clean_up(); exit;  };     
 }
 
 sub __placeholder {}


### PR DESCRIPTION
The last two lines of the import function are modified.  1) No share is created if the compile-only switch was specified -c on the perl command line.  2) Default interrupt and termination handlers are installed to clean up the memory lock if the program is interrupted.